### PR TITLE
Replace GlobalEnv search for model name

### DIFF
--- a/R/anneal.R
+++ b/R/anneal.R
@@ -730,13 +730,13 @@ hessian = TRUE, delta = 100, slimit = 2, c = 2, note = "", show_display = TRUE, 
                                           else pdfname<-"User-defined function"
 
     # Find out what the user called the model
-    model_name<-""
-    base_all<-ls(.GlobalEnv)
-    for (i in 1:length(base_all)) {
-      if (identical(get(base_all[i], pos=.GlobalEnv),model)) {
-        model_name<-base_all[i]
-      }
-    }
+    model_name <- deparse(substitute(model))
+    #base_all<-ls(.GlobalEnv)
+    #for (i in 1:length(base_all)) {
+     # if (identical(get(base_all[i], pos=.GlobalEnv),model)) {
+     #   model_name<-base_all[i]
+     # }
+    #}
 
     # Calculate the standard errors, if requested
     if (hessian) {


### PR DESCRIPTION
solve scoping issue when search global environment for the model name. 

I'm hoping this is a helpful solution here. At line 733, the anneal function searches the global environment for the model name for the final output. I love the functionality of the package but I'm having trouble using this function within a larger function that I'm am writing because the search of the Global environment immediately skips my local environment where the model is defined. My suggestion should return the user input model as a string which can then be saved in the output. 

